### PR TITLE
feature(435673): Prevent widget rendered multiple times and added support for pre-configured email in options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
-  "name": "live-chat-web-sdk",
-  "version": "1.0.0",
+  "name": "@bolddesk/live-chat-web-sdk",
+  "version": "1.0.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "live-chat-web-sdk",
-      "version": "1.0.0",
-      "license": "MIT",
+      "name": "@bolddesk/live-chat-web-sdk",
+      "version": "1.0.0-beta.1",
+      "license": "SEE LICENSE IN README.md",
       "devDependencies": {
         "@rollup/plugin-typescript": "^8.4.0",
         "rimraf": "^3.0.2",

--- a/src/live-chat.ts
+++ b/src/live-chat.ts
@@ -1,15 +1,22 @@
 declare global {
   var $boldChat: any;
+  var boldChatSettings: {
+    email?: string;
+  };
 }
 
 /** Optional configuration for the live chat widget. */
 interface Options {
   /** The locale code (e.g., 'en-US', 'fr') used to load a localized version of the widget script.*/
   locale?: string;
+  /** The user's email address that will be automatically pre-configured in the chat widget, eliminating the need for manual entry. */
+  email?: string;
 }
 
 class LiveChat {
   private widgetScriptUrl: string = '';
+  /** Flag to track whether the chat widget script has already been injected into the DOM to prevent duplicate loading. */
+  private isScriptInjected: boolean = false;
 
   /**
    * Configures the live chat widget URL using the given widget and brand IDs and an optional locale.
@@ -23,6 +30,13 @@ class LiveChat {
     if (!widgetId || !brandUrl) {
       throw new Error(" Website ID and Brand ID should be set to configure bold chat")
     }
+
+    // Set email in boldChatSettings if provided
+    if (options.email?.trim() !== '') {
+      window.boldChatSettings = window.boldChatSettings || {};
+      window.boldChatSettings.email = options.email;
+    }
+
     this.widgetScriptUrl = `${brandUrl}/chatwidget-api/widget/v1/${widgetId}${options.locale ? `?culture=${options.locale}` : ''}`;
     this.load();
   }
@@ -31,6 +45,11 @@ class LiveChat {
    * Injects the chat widget script into the document head. Defers to deferredLoading if head is unavailable.
    */
   private load(): void {
+    // Prevents the live chat widget from being rendered multiple times.
+    if (this.isScriptInjected) {
+      return;
+    }
+
     const head = document.getElementsByTagName("head");
     if (!head || !head[0]) {
       this.deferredLoading();
@@ -40,6 +59,7 @@ class LiveChat {
     script.src = this.widgetScriptUrl;
     script.async = true;
     head[0].appendChild(script);
+    this.isScriptInjected = true;
   }
 
   /** Ensures that the global $boldChat array is initialized. */


### PR DESCRIPTION
**Summary:**

1.  Added a check to ensure that script is injected into DOM only once. This helps prevent the live chat widget from being rendered multiple times.
2. Added email property in options - using which users can pre-configure the email for the widget.
The email should be configured as below:
` LiveChat.configure("b418f1e0-c8ea-4782-99e2-38e08baaa369", "https://stagingboldsign.bolddesk.com", {email: 'jalagandeswaran.s@syncfusion.com'});`